### PR TITLE
Update Debian Version to Resolve GLIBC Compatibility Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY ./ ./
 RUN RUSTFLAGS="$(cat /.rustflags)" cargo build --release --config net.git-fetch-with-cli=true --target $(cat /.platform)
 RUN cp /magi/target/$(cat /.platform)/release/magi /magi/magi
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=build /magi/magi /usr/local/bin


### PR DESCRIPTION
## Description of Changes

Currently, the image is being built using the `rust:latest` base image, which is based on `debian:bullseye`, where:

```
ldd --version
ldd (Debian GLIBC 2.31-13+deb11u6) 2.31
```


Then, the final binary is placed in the `debian:buster` image, where version is:

```
ldd --version
ldd (Debian GLIBC 2.28-10+deb10u2) 2.28
```


This leads to an error during application startup, due to a missing `GLIBC_2.29` version, as shown below:

```
magi: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by magi)
```


To resolve this issue and ensure library compatibility, it's recommended to use the same Debian version for both images. In this case, it's proposed to switch from `debian:buster-slim` to `debian:bullseye-slim`.

## Changes in Dockerfile

```diff
-FROM debian:buster-slim
+FROM debian:bullseye-slim
